### PR TITLE
Pr

### DIFF
--- a/FreeAIr.sln
+++ b/FreeAIr.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.4.11626.88 stable
+VisualStudioVersion = 18.4.11626.88
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FreeAIr", "FreeAIr\FreeAIr.csproj", "{24D4A8F4-E878-4174-BE99-FA4132A5DD00}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -25,9 +25,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MarkdownParser", "MarkdownParser\MarkdownParser.csproj", "{4A1CBEBC-86AC-43C4-9704-4F339B9AB910}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7D1D16BA-A117-42D2-8A73-1C70EBA29A01}"
-	ProjectSection(SolutionItems) = preProject
-		changelog.md = changelog.md
-	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/FreeAIr.sln
+++ b/FreeAIr.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.14.36025.13
+# Visual Studio Version 18
+VisualStudioVersion = 18.4.11626.88 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FreeAIr", "FreeAIr\FreeAIr.csproj", "{24D4A8F4-E878-4174-BE99-FA4132A5DD00}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -23,6 +23,11 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MarkdownParserTester", "MarkdownParserTester\MarkdownParserTester.csproj", "{338FF78A-F88E-468E-9857-63B807B17E8F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MarkdownParser", "MarkdownParser\MarkdownParser.csproj", "{4A1CBEBC-86AC-43C4-9704-4F339B9AB910}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7D1D16BA-A117-42D2-8A73-1C70EBA29A01}"
+	ProjectSection(SolutionItems) = preProject
+		changelog.md = changelog.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/FreeAIr/Chat/Chat.cs
+++ b/FreeAIr/Chat/Chat.cs
@@ -10,11 +10,13 @@ using System.Threading.Tasks;
 using FreeAIr.Chat.Content;
 using FreeAIr.Chat.Context;
 using FreeAIr.BLogic.Reader;
+using stdole;
 
 namespace FreeAIr.Chat
 {
     public sealed class Chat : IAsyncDisposable
     {
+        public Guid Id { get; } = Guid.NewGuid();
         private readonly List<IChatContent> _contents = new();
 
         //private CancellationTokenSource _cancellationTokenSource = new();

--- a/FreeAIr/Chat/ChatContainer.cs
+++ b/FreeAIr/Chat/ChatContainer.cs
@@ -1,17 +1,29 @@
 ﻿using EnvDTE;
 using EnvDTE80;
+using FreeAIr.Options2.Agent;
 using FreeAIr.Shared.Helper;
 using FreeAIr.UI.Informer;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Windows.Forms;
+
 
 namespace FreeAIr.Chat
 {
     [Export(typeof(ChatContainer))]
     public sealed class ChatContainer
     {
+        public Guid? LastUsedChatId { get; set; } = null;
+        public Chat GetLastUsed()
+        {
+            var ctrlPressed = (Control.ModifierKeys & Keys.Control) == Keys.Control;
+            if (ctrlPressed || LastUsedChatId == null) return (null);
+            return (_chats?.FirstOrDefault(c => c.Id == LastUsedChatId));
+        }
+
+
         private readonly object _locker = new();
 
         private readonly UIInformer _uIInformer;

--- a/FreeAIr/Chat/ChatContainer.cs
+++ b/FreeAIr/Chat/ChatContainer.cs
@@ -19,8 +19,8 @@ namespace FreeAIr.Chat
         public Chat GetLastUsed()
         {
             var ctrlPressed = (Control.ModifierKeys & Keys.Control) == Keys.Control;
-            if (ctrlPressed || LastUsedChatId == null) return (null);
-            return (_chats?.FirstOrDefault(c => c.Id == LastUsedChatId));
+            if (ctrlPressed && LastUsedChatId != null) return (_chats?.FirstOrDefault(c => c.Id == LastUsedChatId));
+            return (null);
         }
 
 
@@ -92,7 +92,7 @@ namespace FreeAIr.Chat
             {
                 chat.AddPrompt(prompt);
             }
-
+            LastUsedChatId = chat.Id;
             return chat;
         }
 

--- a/FreeAIr/Chat/ChatDescription.cs
+++ b/FreeAIr/Chat/ChatDescription.cs
@@ -1,7 +1,16 @@
-﻿namespace FreeAIr.Chat
+﻿using FreeAIr.Shared.ish;
+
+namespace FreeAIr.Chat
 {
-    public sealed class ChatDescription : IDisposable
+    public sealed class ChatDescription : cNotifyBase, IDisposable
     {
+
+        public string Title
+        {
+            get => field;
+            set => SetProperty(ref field, value);
+        }
+
         public IOriginalTextDescriptor? SelectedTextDescriptor
         {
             get;
@@ -12,6 +21,7 @@
             )
         {
             SelectedTextDescriptor = selectedTextDescriptor;
+            Title = "Untitled";
         }
 
         public void Dispose()

--- a/FreeAIr/Commands/ShowInSituChatCommand.cs
+++ b/FreeAIr/Commands/ShowInSituChatCommand.cs
@@ -9,34 +9,24 @@ namespace FreeAIr.Commands
     [Command(PackageIds.ShowInSituChatCommandId)]
     public sealed class ShowInSituChatCommand : BaseCommand<ShowInSituChatCommand>
     {
-        public ShowInSituChatCommand(
-            )
-        {
-        }
+        public ShowInSituChatCommand(){ }
 
         protected override async Task ExecuteAsync(OleMenuCmdEventArgs e)
         {
-            var chosenAgent = await AgentContextMenu.ChooseAgentWithTokenAsync(
-                FreeAIr.Resources.Resources.Choose_agent__with_a_non_empty_token
-                );
-            if (chosenAgent is null)
-            {
-                return;
-            }
-
             var componentModel = (IComponentModel)await FreeAIrPackage.Instance.GetServiceAsync(typeof(SComponentModel));
             var chatContainer = componentModel.GetService<ChatContainer>();
 
-            var chat = await chatContainer.StartChatAsync(
-                new ChatDescription(null),
-                null,
-                await FreeAIr.Chat.ChatOptions.GetDefaultAsync(chosenAgent)
-                );
+            var chat = chatContainer.GetLastUsed();
 
-            await ChatWindowShower.ShowChatWindowAsync(
-                chat,
-                true
-                );
+            if (chat == null)
+            {
+                var chosenAgent = await AgentContextMenu.ChooseAgentWithTokenAsync(FreeAIr.Resources.Resources.Choose_agent__with_a_non_empty_token);
+                if (chosenAgent is null) return;
+
+                chat = await chatContainer.StartChatAsync(new ChatDescription(null),null,await FreeAIr.Chat.ChatOptions.GetDefaultAsync(chosenAgent));
+            }
+
+            await ChatWindowShower.ShowChatWindowAsync(chat,true);
         }
 
     }

--- a/FreeAIr/Commands/StartDiscussionCommand.cs
+++ b/FreeAIr/Commands/StartDiscussionCommand.cs
@@ -5,6 +5,7 @@ using FreeAIr.UI.ToolWindows;
 using Microsoft.VisualStudio.ComponentModelHost;
 using FreeAIr.Chat;
 using FreeAIr.Chat.Context.Item;
+using System.Windows.Input;
 
 namespace FreeAIr.Commands
 {
@@ -33,74 +34,44 @@ namespace FreeAIr.Commands
                 return;
             }
 
+            var chat = chatContainer.GetLastUsed();
 
-            //try
-            //{
-            //    var dte = AsyncPackage.GetGlobalService(typeof(EnvDTE.DTE)) as DTE2;
-            //    dte.ExecuteCommand("OtherContextMenus.inlinediffsettings.Diff.InlineView");
-
-            //    var differenceService = (IVsDifferenceService)await FreeAIrPackage.Instance.GetServiceAsync(typeof(SVsDifferenceService));
-
-            //    var leftPath = @"C:\temp\file1.txt";
-            //    var rightPath = @"C:\temp\file2.txt";
-            //    var caption = "My Diff";
-            //    var tooltip = "Inline diff between two files";
-
-            //    IVsWindowFrame frame = differenceService.OpenComparisonWindow2(
-            //        leftFileMoniker: leftPath,
-            //        rightFileMoniker: rightPath,
-            //        caption: caption,
-            //        Tooltip: tooltip,
-            //        leftLabel: "left file", // не используется
-            //        rightLabel: "right file", // не используется
-            //        inlineLabel: "inline label", // не используется
-            //        roles: "roles roles", // не используется
-            //        grfDiffOptions: (uint)__VSDIFFSERVICEOPTIONS.VSDIFFOPT_DoNotShow
-            //    );
-
-            //    frame.Show();
-
-            //    //OtherContextMenus.inlinediffsettings.Diff.InlineView
-
-
-            //}
-            //catch (Exception excp)
-            //{
-            //    int g = 0;
-            //}
-            //return;
-
-
-
-
-            var chosenAgent = await AgentContextMenu.ChooseAgentWithTokenAsync(
-                "Choose agent:"
-                );
-            if (chosenAgent is null)
+            if (chat == null)
             {
-                return;
+                var chosenAgent = await AgentContextMenu.ChooseAgentWithTokenAsync(
+                    "Choose agent:"
+                    );
+                if (chosenAgent is null)
+                {
+                    return;
+                }
+
+
+                    chat = await chatContainer.StartChatAsync(
+                    new ChatDescription(
+                        null
+                        ),
+                    null,
+                    await FreeAIr.Chat.ChatOptions.GetDefaultAsync(chosenAgent)
+                    );
+                chatContainer.LastUsedChatId = chat.Id;
             }
+            if (chat == null) return;
 
-
-            var chat = await chatContainer.StartChatAsync(
-                new ChatDescription(
-                    null
-                    ),
-                null,
-                await FreeAIr.Chat.ChatOptions.GetDefaultAsync(chosenAgent)
-                );
-            if (chat is null)
+            try
             {
-                return;
+                chat.ChatContext.AddItem(
+                    new SolutionItemChatContextItem(
+                        std.CreateSelectedIdentifier(),
+                        false,
+                        AddLineNumbersMode.NotRequired
+                        )
+                    );
             }
-
-            chat.ChatContext.AddItem(
-                new SolutionItemChatContextItem(
-                    std.CreateSelectedIdentifier(),
-                    false,
-                    AddLineNumbersMode.NotRequired
-                    )
-                );
+            catch (Exception ex)
+            {
+                int a = 1;
+            }
 
             await ChatWindowShower.ShowChatWindowAsync(chat);
         }

--- a/FreeAIr/Commands/StartDiscussionCommand.cs
+++ b/FreeAIr/Commands/StartDiscussionCommand.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.ComponentModelHost;
 using FreeAIr.Chat;
 using FreeAIr.Chat.Context.Item;
 using System.Windows.Input;
+using System.Diagnostics;
 
 namespace FreeAIr.Commands
 {
@@ -38,23 +39,9 @@ namespace FreeAIr.Commands
 
             if (chat == null)
             {
-                var chosenAgent = await AgentContextMenu.ChooseAgentWithTokenAsync(
-                    "Choose agent:"
-                    );
-                if (chosenAgent is null)
-                {
-                    return;
-                }
-
-
-                    chat = await chatContainer.StartChatAsync(
-                    new ChatDescription(
-                        null
-                        ),
-                    null,
-                    await FreeAIr.Chat.ChatOptions.GetDefaultAsync(chosenAgent)
-                    );
-                chatContainer.LastUsedChatId = chat.Id;
+                var chosenAgent = await AgentContextMenu.ChooseAgentWithTokenAsync("Choose agent:");
+                if (chosenAgent == null) return;
+                chat = await chatContainer.StartChatAsync( new ChatDescription(null), null, await FreeAIr.Chat.ChatOptions.GetDefaultAsync(chosenAgent));
             }
             if (chat == null) return;
 
@@ -70,7 +57,7 @@ namespace FreeAIr.Commands
             }
             catch (Exception ex)
             {
-                int a = 1;
+                Debug.WriteLine( ex.Message );
             }
 
             await ChatWindowShower.ShowChatWindowAsync(chat);

--- a/FreeAIr/FreeAIr.csproj
+++ b/FreeAIr/FreeAIr.csproj
@@ -602,6 +602,9 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="ish\" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <Target Name="IncludeNuGetPackageReferences" AfterTargets="GetVsixSourceItems">

--- a/FreeAIr/FreeAIr.csproj
+++ b/FreeAIr/FreeAIr.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <LangVersion>Latest</LangVersion>
+    <LangVersion>Preview</LangVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -616,7 +616,7 @@
   <PropertyGroup>
     <PostBuildEvent>set "DIRS_TO_ZIP=win-x64 vulkan\win-x64"
 set "ZIP_NAME=$(SolutionDir).art\WhisperNet.Runtime.zip"
-PowerShell.exe -ExecutionPolicy Bypass -File "$(SolutionDir).CreateZipArchive.ps1" -DirsToZip "%25DIRS_TO_ZIP%25" -ZipName "%25ZIP_NAME%25" -RootDir "$(TargetDir)runtimes"
+PowerShell.exe -ExecutionPolicy Bypass -File "$(SolutionDir).\.CreateZipArchive.ps1" -DirsToZip "%25DIRS_TO_ZIP%25" -ZipName "%25ZIP_NAME%25" -RootDir "$(TargetDir)runtimes"
 </PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/FreeAIr/UI/ContextMenu/ModelContextMenu.cs
+++ b/FreeAIr/UI/ContextMenu/ModelContextMenu.cs
@@ -3,7 +3,9 @@ using FreeAIr.Shared.Helper;
 using OpenAI;
 using OpenAI.Models;
 using System.ClientModel;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace FreeAIr.UI.ContextMenu
@@ -14,7 +16,8 @@ namespace FreeAIr.UI.ContextMenu
             string token,
             string endpoint,
             string title,
-            string? preferredModelId = null
+            string? preferredModelId = null,
+            string mask = null, bool isRegex = false
             )
         {
             if (title is null)
@@ -54,17 +57,50 @@ namespace FreeAIr.UI.ContextMenu
                 }
             }
 
-            var chosen = await VisualStudioContextMenuCommandBridge.ShowAsync<OpenAIModel>(
-                title,
-                models
-                    .ConvertAll(a => (a.Id, a as object))
-                );
+            List<(string, object)> _filtredModels = null;
+            var filter = _getFilter(mask, isRegex);
+            try
+            {
+                _filtredModels = models.Where(m => filter(m)).Select(m => (m.Id, (object)m)).ToList();
+            }
+            catch (Exception ex) when (ex is ArgumentException
+                                    or ArgumentNullException
+                                    or ArgumentOutOfRangeException
+                                    or RegexMatchTimeoutException)
+            {
+                filter = _getFilter(mask, false);
+                _filtredModels = models.Where(m => filter(m)).Select(m => (m.Id, (object)m)).ToList();
+            }
+            if (models.Count > 30) title += $" ({_filtredModels.Count} out of {models.Count})";
+
+            var chosen = await VisualStudioContextMenuCommandBridge.ShowAsync<OpenAIModel>(title,_filtredModels);
+
             if (chosen is null)
             {
                 return null;
             }
 
             return chosen.Id;
+        }
+
+        static Func<OpenAIModel, bool> _getFilter(string mask, bool isRegex)
+        {
+            Func<OpenAIModel, bool> filter;
+            if (string.IsNullOrEmpty(mask))
+            {
+                filter = _ => true;
+            }
+            else if (isRegex)
+            {
+                var regex = new Regex(mask, RegexOptions.IgnoreCase);
+                filter = m => regex.IsMatch(m.Id) || (m.OwnedBy != null && regex.IsMatch(m.OwnedBy));
+            }
+            else
+            {
+                filter = m => m.Id.Contains(mask, StringComparison.OrdinalIgnoreCase)
+                           || (m.OwnedBy?.Contains(mask, StringComparison.OrdinalIgnoreCase) ?? false);
+            }
+            return (filter);
         }
 
     }

--- a/FreeAIr/UI/Embedillo/Answer/Parser/SelectedSpan.cs
+++ b/FreeAIr/UI/Embedillo/Answer/Parser/SelectedSpan.cs
@@ -62,10 +62,7 @@ namespace FreeAIr.UI.Embedillo.Answer.Parser
             SelectedSpan? selection
             )
         {
-            if (solutionFilePath is null)
-            {
-                throw new ArgumentNullException(nameof(solutionFilePath));
-            }
+            
 
             if (filePath is null)
             {

--- a/FreeAIr/UI/ToolWindows/ChatListToolWindowControl.xaml
+++ b/FreeAIr/UI/ToolWindows/ChatListToolWindowControl.xaml
@@ -21,10 +21,13 @@
     mc:Ignorable="d"
     d:DesignHeight="300"
     d:DesignWidth="300"
-    Name="ChatListToolWindow"
+    d:DataContext ="{d:DesignInstance Type=viewmodels:ChatListViewModel, IsDesignTimeCreatable=False}"
+    x:Name="ChatListToolWindow"
+    
     IsVisibleChanged="ChatListToolWindow_IsVisibleChanged"
     DragDrop.Drop="ChatListToolWindow_Drop"
     >
+    
     <Grid
         Margin="2"
         >
@@ -145,12 +148,16 @@
                 ScrollViewer.HorizontalScrollBarVisibility="Auto"
                 ScrollViewer.VerticalScrollBarVisibility="Auto"
                 >
+                <ListBox.ContextMenu>
+                        <ContextMenu>
+                            <MenuItem Header="Rename" Command="{Binding cmdRenameChat}"/>
+                        </ContextMenu>
+                </ListBox.ContextMenu>
                 <ListBox.ItemTemplate>
                     <DataTemplate>
 
-                        <StackPanel
-                            Opacity="{Binding OpacityLevel}"
-                            >
+                        <StackPanel Opacity="{Binding OpacityLevel}">
+                            <Label Content="{Binding Title}" />
                             <TextBlock
                                 FontFamily="Cascadia Code"
                                 Visibility="{Binding SecondRowVisibility}"

--- a/FreeAIr/UI/ViewModels/AgentConfigureViewModel.cs
+++ b/FreeAIr/UI/ViewModels/AgentConfigureViewModel.cs
@@ -251,6 +251,32 @@ namespace FreeAIr.UI.ViewModels
             }
         }
 
+        public string ModelFilter
+        {
+            get => field;
+            set
+            {
+                if (value != field)
+                {
+                    field = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public bool IsMaskRegex
+        {
+            get => field;
+            set
+            {
+                if (value != field)
+                {
+                    field = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
         public ICommand ChooseModelCommand
         {
             get
@@ -264,7 +290,7 @@ namespace FreeAIr.UI.ViewModels
                                 token: SelectedAgent.Technical.GetToken(),
                                 endpoint: SelectedAgent.Technical.Endpoint,
                                 title: FreeAIr.Resources.Resources.Choose_model_from_this_api_endpoint,
-                                null
+                                null, ModelFilter, IsMaskRegex
                                 );
                             if (string.IsNullOrEmpty(chosenModelId))
                             {

--- a/FreeAIr/UI/ViewModels/ChatListViewModel.cs
+++ b/FreeAIr/UI/ViewModels/ChatListViewModel.cs
@@ -8,7 +8,9 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Input;
 using WpfHelpers;
+using WpfHelpers.ish;
 using FreeAIr.Chat;
+using FreeAIr.Shared.ish;
 
 namespace FreeAIr.UI.ViewModels
 {
@@ -119,6 +121,27 @@ namespace FreeAIr.UI.ViewModels
                     ;
             }
         }
+
+        #region ish
+        public cMyCommand cmdRenameChat => field ??= cMyCommand.Create(RenameChat);
+        void RenameChat()
+        {
+            var wrapper = SelectedChat;
+            if (wrapper == null) return;
+
+            var newName =  ShowRenameDialog(wrapper.Title);
+            if (!string.IsNullOrEmpty(newName))
+            {
+                wrapper.Title = newName;
+                wrapper.Update();
+            }
+        }
+        string ShowRenameDialog(string currentTitle)
+        {
+            var input = new cInputDlg("New chat name", currentTitle, "Enter new name ");
+            return ((input.ShowDialog() == true) ? (string)input.Value : string.Empty);
+        }
+        #endregion
 
 
         public ICommand RemoveChatCommand
@@ -313,7 +336,7 @@ namespace FreeAIr.UI.ViewModels
             SelectedChat = ChatList.FirstOrDefault();
         }
 
-        public sealed class ChatWrapper : BaseViewModel
+        public sealed class  ChatWrapper : BaseViewModel
         {
             public FreeAIr.Chat.Chat Chat
             {
@@ -357,6 +380,12 @@ namespace FreeAIr.UI.ViewModels
                         : Visibility.Visible
                         ;
                 }
+            }
+
+            public string Title
+            {
+                get => Chat.Description?.Title;
+                set => Chat.Description?.Title = value;
             }
 
             public string SecondRow

--- a/FreeAIr/UI/Windows/AgentConfigureWindow.xaml
+++ b/FreeAIr/UI/Windows/AgentConfigureWindow.xaml
@@ -17,6 +17,8 @@
     Title="{x:Static resources:Resources.FreeAIr_Agent_Configuration_Window}"
     Loaded="Window_Loaded"
     xmlns:resources="clr-namespace:FreeAIr.Resources"
+    xmlns:vm="clr-namespace:FreeAIr.UI.ViewModels"
+    d:DataContext="{d:DesignInstance Type=vm:AgentConfigureViewModel, IsDesignTimeCreatable=False}"
     >
     <Grid>
         <Grid.RowDefinitions>
@@ -238,6 +240,9 @@
                 >
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition />
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="auto" />
                     <ColumnDefinition Width="auto" />
                 </Grid.ColumnDefinitions>
             
@@ -248,13 +253,16 @@
                     FontFamily="Cascadia Code"
                     Text="{Binding SelectedAgent.Technical.ChosenModel, UpdateSourceTrigger=PropertyChanged}"
                     />
-
+                <Label Grid.Column="1" Content="Filter" Margin="5,0,2,0" />
+                <TextBox Grid.Column="2" Text="{Binding ModelFilter }" />
+                <CheckBox Grid.Column="3" Content="Rx" IsChecked="{Binding IsMaskRegex}" Margin="2" />
                 <Button
-                    Grid.Column="1"
+                    Grid.Column="4"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Center"
                     Margin="2,0,0,0"
                     Command="{Binding ChooseModelCommand}"
+                    ToolTip="Show model list"
                     >
                     <Button.Content>
                         <ui:PseudoCrispImage

--- a/FreeAIr/VSCommandTable.vsct
+++ b/FreeAIr/VSCommandTable.vsct
@@ -192,7 +192,7 @@
         <Icon guid="ImageCatalogGuid" id="ApplyCodeChanges" />
         <CommandFlag>IconIsMoniker</CommandFlag>
         <Strings>
-          <ButtonText>FreeAIr start discussion with...</ButtonText>
+          <ButtonText>FreeAIr start discussion with...(Ctrl=prev chat)</ButtonText>
         </Strings>
       </Button>
       <Button guid="FreeAIr" id="GenerateWholeLineSuggestionCommandId" priority="0x0002" type="Button">
@@ -208,7 +208,7 @@
         <Icon guid="ImageCatalogGuid" id="NeuralNetwork" />
         <CommandFlag>IconIsMoniker</CommandFlag>
         <Strings>
-          <ButtonText>FreeAIr start chat here...</ButtonText>
+          <ButtonText>FreeAIr start chat here...(Ctrl=prev chat)</ButtonText>
         </Strings>
       </Button>
 

--- a/Shared/FreeAIr.Shared.csproj
+++ b/Shared/FreeAIr.Shared.csproj
@@ -15,6 +15,7 @@
     <WarningsAsErrors>nullable;CS8766;CS8767</WarningsAsErrors>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -35,6 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.Text.Data, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -44,12 +46,15 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ish\cNotifyBase.cs" />
     <Compile Include="Dto\UnitInfo.cs" />
     <Compile Include="Dto\CodeLensTarget.cs" />
     <Compile Include="Helper\ListHelper.cs" />
     <Compile Include="ICodeLensListener.cs" />
+    <Compile Include="ish\cMyCommand.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="CommonConnection.cs" />
     <Compile Include="Dto\CodeLensUnitInfo.cs" />

--- a/Shared/ish/cMyCommand.cs
+++ b/Shared/ish/cMyCommand.cs
@@ -1,0 +1,28 @@
+﻿#nullable disable
+namespace FreeAIr.Shared.ish
+{
+    using System;
+    using System.Threading.Tasks;
+    using System.Windows.Input;
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "<Pending>")]
+    public class cMyCommand : ICommand
+    {
+        public Predicate<object> CanExecuteDelegate { get; set; }
+        public Action<object> ExecuteDelegate { get; set; }
+
+        public bool CanExecute(object parameter) => (CanExecuteDelegate != null) ? CanExecuteDelegate(parameter) : true;
+
+        public event EventHandler CanExecuteChanged
+        {
+            add  => CommandManager.RequerySuggested += value; 
+            remove => CommandManager.RequerySuggested -= value; 
+        }
+        public void Execute(object parameter) => ExecuteDelegate?.Invoke(parameter);
+
+        public static cMyCommand Create(Action<object> executeDelegate) => new() { ExecuteDelegate = executeDelegate };
+        public static cMyCommand Create(Action executeDelegate) => new() { ExecuteDelegate = (o) => executeDelegate?.Invoke() };
+        public static cMyCommand Create(Func<bool> executeDelegate) => new() { ExecuteDelegate = (o) => executeDelegate?.Invoke() };
+        public static cMyCommand Create(Func<Task> executeDelegate) =>new() { ExecuteDelegate = async (o) => await executeDelegate() };
+    }
+}

--- a/Shared/ish/cNotifyBase.cs
+++ b/Shared/ish/cNotifyBase.cs
@@ -1,0 +1,23 @@
+﻿#nullable disable
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace FreeAIr.Shared.ish
+{
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "<Pending>")]
+    public class cNotifyBase : INotifyPropertyChanged
+        {
+            public event PropertyChangedEventHandler PropertyChanged ;
+            protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = "") => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            protected bool SetProperty<T>(ref T field, T value, Action OnOk = null, [CallerMemberName] string propertyName = "")
+            {
+                if (EqualityComparer<T>.Default.Equals(field, value)) return (false);
+                field = value;
+                OnPropertyChanged(propertyName);
+                OnOk?.Invoke();
+                return (true);
+            }
+        }
+}

--- a/WpfHelpers/ish/cInputDlg.xaml
+++ b/WpfHelpers/ish/cInputDlg.xaml
@@ -1,0 +1,37 @@
+﻿<Window x:Class="WpfHelpers.ish.cInputDlg"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:WpfHelpers.ish"
+        mc:Ignorable="d"
+        Title="" Height="180" Width="400"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        x:Name="this_wnd">
+    
+    <Grid Margin="15">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <Label x:Name="lbLabel" Grid.Row="0" Margin="0,0,0,10"/>
+
+        <TextBox x:Name="tbValue" Grid.Row="1" Margin="0,0,0,10" Visibility="Collapsed"/>
+        <DatePicker x:Name="dpValue" Grid.Row="1" Margin="0,0,0,10" Visibility="Collapsed"/>
+
+        <TextBlock x:Name="ErrorBlock"
+                   Grid.Row="2"
+                   Foreground="Red"
+                   TextWrapping="Wrap"
+                   Visibility="Collapsed"/>
+
+        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="OK" MinWidth="70" Click="Ok_Click" IsDefault="True"/>
+            <Button Content="Отмена" MinWidth="70" IsCancel="True" Margin="5,0,0,0"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/WpfHelpers/ish/cInputDlg.xaml.cs
+++ b/WpfHelpers/ish/cInputDlg.xaml.cs
@@ -1,0 +1,62 @@
+﻿#nullable disable
+using System;
+using System.Windows;
+
+namespace WpfHelpers.ish
+{
+    /// <summary>
+    /// Interaction logic for cInputDlg.xaml
+    /// </summary>
+    public partial class cInputDlg : Window
+    {
+        public enum InputValueType  {Text, Date };
+        readonly InputValueType _inputValueType;
+        readonly Func<object, string> _validator;
+        public object Value { get; private set;  }
+        Func<object> _getValue;
+
+        public cInputDlg( string Label, object defaultValue = null,  string DlgTitle = "Введите значение",  InputValueType valueType = InputValueType.Text, Func<object,string> validator = null )
+        {
+            InitializeComponent();
+            Title = DlgTitle;
+            lbLabel.Content = Label;
+            _inputValueType = valueType;
+            _validator = validator;
+
+            switch (_inputValueType)
+            {
+                case InputValueType.Date:
+                    dpValue.Visibility = Visibility.Visible;
+                    if (defaultValue != null && defaultValue is DateTime dt) dpValue.SelectedDate = dt;
+                    dpValue.Focus();
+                    _getValue = _getDatePickerValue;
+                    break;
+                default:
+                    tbValue.Visibility = Visibility.Visible;
+                    if (defaultValue != null && defaultValue is string s) tbValue.Text = s;
+                    tbValue.Focus();
+                    _getValue = _getTextValue;
+                    break;
+            }
+        }
+
+        private void Ok_Click(object sender, RoutedEventArgs e)
+        {
+            object value = _getValue();
+            string  errmsg = _validator?.Invoke(value);
+            if (!string.IsNullOrEmpty(errmsg))
+            {
+                ErrorBlock.Text = errmsg;
+                ErrorBlock.Visibility = Visibility.Visible;
+                return;
+            }
+
+            Value = value;
+            DialogResult = true;
+            Close();
+        }
+
+        object _getTextValue() => tbValue.Text;
+        object _getDatePickerValue() => (dpValue.SelectedDate is DateTime dt) ? dt : null;
+    }
+}

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,16 @@
+#FreeAir fork (by ish ) changes
+
+## Unreleased
+
+### Fixed
+- Fixed PostBuildEvent for WhisperNet.Runtime.zip: added explicit .\ to script path.
+- Build now succeeds in VS 2022 & VS 2026
+- added changelog.md (this file)
+
+
+### TODO
+- [ ] Rename chat (context menu)
+- [ ] Chat selection (new/existing + model choice)
+- [ ] Font settings
+- [ ] Chat trim
+- [ ] Code coloring

--- a/changelog.md
+++ b/changelog.md
@@ -6,17 +6,19 @@
 - Fixed PostBuildEvent for WhisperNet.Runtime.zip: added explicit .\ to script path.
 - Build now succeeds in VS 2022 & VS 2026
 - added changelog.md (this file)
+- removed ANE throw on solutionPath = null in SelectedIdentifier.ctor, prevented to work with separate files.
 
 ### Added/Modified
 - Added Title to ChatWrapper, ChatDescription, ChatListToolWindowControl
 - FreeAir.Shared: added cNotifyBase class for easy INPC, cMyCommand
 - wpfHelpers: added cInputDlg 
-- rename chat in a chat list (via listbox context menu)
+- chat rename in a chat list (via listbox context menu)
+- start discussion , start chat here -  hold Ctrl to add to previous chat 
 
 
 ### TODO
 - [x] Rename chat (context menu)
-- [ ] Chat selection (new/existing + model choice)
+- [x] Chat selection (new/existing)
 - [ ] Font settings
 - [ ] Chat trim
 - [ ] Code coloring

--- a/changelog.md
+++ b/changelog.md
@@ -7,9 +7,15 @@
 - Build now succeeds in VS 2022 & VS 2026
 - added changelog.md (this file)
 
+### Added/Modified
+- Added Title to ChatWrapper, ChatDescription, ChatListToolWindowControl
+- FreeAir.Shared: added cNotifyBase class for easy INPC, cMyCommand
+- wpfHelpers: added cInputDlg 
+- rename chat in a chat list (via listbox context menu)
+
 
 ### TODO
-- [ ] Rename chat (context menu)
+- [x] Rename chat (context menu)
 - [ ] Chat selection (new/existing + model choice)
 - [ ] Font settings
 - [ ] Chat trim


### PR DESCRIPTION
## Changes

### Added
- Chat rename via context menu in chat list
- Reuse last chat with Ctrl modifier (non-breaking)
  - Regular click: new chat (default behavior)
  - Ctrl+click: add to last used chat
- Title property to ChatDescription
- LastUsedChatId and GetLastUsed() to ChatContainer
- cNotifyBase, cMyCommand, cInputDlg in Shared/WpfHelpers

### Fixed
- SelectedIdentifier now allows null solutionFilePath (fixes crash with temp files outside solution)
- PostBuildEvent for WhisperNet.Runtime.zip

### Notes
- Non-code files (changelog.md) excluded from this PR
- Ctrl modifier logic is backward-compatible